### PR TITLE
fix crash bug. stirp() removes DNS request ID = 2481(0x9 0xb1) aka "\t"

### DIFF
--- a/dnsrebinder.py
+++ b/dnsrebinder.py
@@ -121,7 +121,7 @@ class BaseRequestHandler(socketserver.BaseRequestHandler):
 class TCPRequestHandler(BaseRequestHandler):
 
     def get_data(self):
-        data = self.request.recv(8192).strip()
+        data = self.request.recv(8192)
         sz = struct.unpack('>H', data[:2])[0]
         if sz < len(data) - 2:
             raise Exception("Wrong size of TCP packet")
@@ -137,7 +137,7 @@ class TCPRequestHandler(BaseRequestHandler):
 class UDPRequestHandler(BaseRequestHandler):
 
     def get_data(self):
-        return self.request[0].strip()
+        return self.request[0]
 
     def send_data(self, data):
         return self.request[1].sendto(data, self.client_address)


### PR DESCRIPTION
Removed the two strip() calls as they are harmful in certain cases.
Stirp() removes DNS request ID = 2481(0x9 0xb1) aka "\t"
See https://github.com/apache/trafficserver/issues/5793#issuecomment-524807080 for detaild descripton of this issue.

On a fully updated ubuntu 20.4.4 lts with python 3.8.10 the DNSrebind server crashes with the following stack trace:
```
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 45871
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;rebind.mydomain.mytld.              IN      A
;; ANSWER SECTION:
rebind.mydomain.mytld.       1       IN      A       127.0.0.1
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/dnslib/dns.py", line 683, in parse
    qname = buffer.decode_name()
  File "/usr/local/lib/python3.8/dist-packages/dnslib/label.py", line 255, in decode_name
    l = self.get(length)
  File "/usr/local/lib/python3.8/dist-packages/dnslib/buffer.py", line 63, in get
    raise BufferError("Not enough bytes [offset=%d,remaining=%d,requested=%d]" %
dnslib.buffer.BufferError: Not enough bytes [offset=13,remaining=35,requested=112]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "dnsrebinder.py", line 116, in handle
    self.send_data(dns_response(data, self.server.domain, self.server.ip, self.server.rebind, self.server.ttl, self.server.counterMax, self.server.hostCounter))
  File "dnsrebinder.py", line 50, in dns_response
    request = DNSRecord.parse(data)
  File "/usr/local/lib/python3.8/dist-packages/dnslib/dns.py", line 107, in parse
    questions.append(DNSQuestion.parse(buffer))
  File "/usr/local/lib/python3.8/dist-packages/dnslib/dns.py", line 687, in parse
    raise DNSError("Error unpacking DNSQuestion [offset=%d]: %s" % (
dnslib.dns.DNSError: Error unpacking DNSQuestion [offset=13]: Not enough bytes [offset=13,remaining=35,requested=112]
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/dnslib/dns.py", line 683, in parse
    qname = buffer.decode_name()
  File "/usr/local/lib/python3.8/dist-packages/dnslib/label.py", line 255, in decode_name
    l = self.get(length)
  File "/usr/local/lib/python3.8/dist-packages/dnslib/buffer.py", line 63, in get
    raise BufferError("Not enough bytes [offset=%d,remaining=%d,requested=%d]" %
dnslib.buffer.BufferError: Not enough bytes [offset=13,remaining=35,requested=112]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "dnsrebinder.py", line 116, in handle
    self.send_data(dns_response(data, self.server.domain, self.server.ip, self.server.rebind, self.server.ttl, self.server.counterMax, self.server.hostCounter))
  File "dnsrebinder.py", line 50, in dns_response
    request = DNSRecord.parse(data)
  File "/usr/local/lib/python3.8/dist-packages/dnslib/dns.py", line 107, in parse
    questions.append(DNSQuestion.parse(buffer))
  File "/usr/local/lib/python3.8/dist-packages/dnslib/dns.py", line 687, in parse
    raise DNSError("Error unpacking DNSQuestion [offset=%d]: %s" % (
dnslib.dns.DNSError: Error unpacking DNSQuestion [offset=13]: Not enough bytes [offset=13,remaining=35,requested=112]```